### PR TITLE
use node-wolfram npm module instead of wolfram

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "passport": "^0.3.2",
     "passport-local": "^1.0.0",
     "twilio": "^2.9.1",
-    "wolfram": "^0.3.2",
+    "node-wolfram": "^0.0.1",
     "xml2js": "^0.4.16"
   }
 }

--- a/services/wolframservice.js
+++ b/services/wolframservice.js
@@ -1,4 +1,5 @@
-var Wolfram = require('wolfram').createClient(process.env.WOLFRAM_ALPHA_APP_ID);
+var WolframClient = require('node-wolfram');
+var Wolfram = new WolframClient(process.env.WOLFRAM_ALPHA_APP_ID);
 
 var WolframFactory = function(){
   return {


### PR DESCRIPTION
The wolfram npm module has a dependency on libxmljs which raises
build issues depending on which platform you are developing on.
node-wolfram uses xml2js instead of libxmljs to convert XML to
JSON, so it does not have this dependency and is more flexible.